### PR TITLE
Allow the gem to be used with Rails 4.

### DIFF
--- a/lib/validates_hostname.rb
+++ b/lib/validates_hostname.rb
@@ -1,4 +1,5 @@
 require 'active_support/concern'
+require 'active_record'
 require 'active_model'
 
 module PAK

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'rails/all'
+require 'active_record'
 require 'rspec/rails'
 
 require 'validates_hostname'

--- a/validates_hostname.gemspec
+++ b/validates_hostname.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 2.14'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'sqlite3-ruby'
+  s.add_development_dependency 'sqlite3'
 end

--- a/validates_hostname.gemspec
+++ b/validates_hostname.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.licenses                  = 'MIT'
   s.require_paths             = ["lib"]
 
-  s.add_runtime_dependency 'activerecord', '~> 3.0'
-  s.add_runtime_dependency 'activesupport', '~> 3.0'
+  s.add_runtime_dependency 'activerecord', '>= 3.0'
+  s.add_runtime_dependency 'activesupport', '>= 3.0'
 
   s.add_development_dependency 'rails'
   s.add_development_dependency 'rspec', '~> 2.14'

--- a/validates_hostname.gemspec
+++ b/validates_hostname.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activerecord', '>= 3.0'
   s.add_runtime_dependency 'activesupport', '>= 3.0'
 
-  s.add_development_dependency 'rails'
   s.add_development_dependency 'rspec', '~> 2.14'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3-ruby'


### PR DESCRIPTION
Using this in a Rails 4 project would block because of the version specified for ActiveRecord.