### PR TITLE
Fix documentation -> should be ~>

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,7 +23,7 @@ As plugin (from master)
 As gem
 
   # in Gemfile
-  gem 'validates_hostname', '-> 1.0.0'
+  gem 'validates_hostname', '~> 1.0'
   
   # Run bundler
   $ bundle install


### PR DESCRIPTION
The current docs say to use gem '-> 1.0.0' but this is invalid according to bundler.

I think it should actually be '~> 1.0' 