### PR TITLE
Fix the numeric hostname check

### DIFF
--- a/lib/validates_hostname.rb
+++ b/lib/validates_hostname.rb
@@ -129,11 +129,7 @@ module PAK
           # CHECK 4: the unqualified hostname portion cannot consist of 
           #          numeric values only
           if options[:allow_numeric_hostname] == false and labels.length > 0
-            is_numeric_only = (
-              (
-                Integer(labels[0]) rescue false
-              ) ? true : false
-            )
+            is_numeric_only = labels[0] =~ /\A\d+\z/
             add_error(record, attribute, :hostname_label_is_numeric) if is_numeric_only
           end
 
@@ -189,11 +185,7 @@ module PAK
             # CHECK 1: if there is only one label it cannot be numeric even
             #          though numeric hostnames are allowed
             if options[:allow_numeric_hostname] == true
-              is_numeric_only = (
-                (
-                  Integer(labels[0]) rescue false
-                ) ? true : false
-              )
+              is_numeric_only = labels[0] =~ /\A\d+\z/
               if is_numeric_only and labels.size == 1
                 add_error(record, attribute, :single_numeric_hostname_label)
               end

--- a/spec/validates_hostname_spec.rb
+++ b/spec/validates_hostname_spec.rb
@@ -261,7 +261,7 @@ describe Record do
                         :name_with_wildcard         => '12345',
                         :name_with_valid_tld        => '12345.org',
                         :name_with_test_tld         => '12345.test',
-                        :name_with_numeric_hostname => 'test',
+                        :name_with_numeric_hostname => '0x12345',
                         :name_with_blank            => '12345',
                         :name_with_nil              => '12345'
     record.save.should_not be_true


### PR DESCRIPTION
Hi,

Thanks for this great gem! We're using it in GitLab EE and I think we've discovered a bug in its evaluation of numeric-only hostnames: a label like `0x10' is incorrectly interpreted as being all-numeric, leading to this bug report: https://gitlab.com/gitlab-org/gitlab-ee/issues/827

I believe this PR will fix the issue while adding a spec to fix it, but unfortunately I wasn't able to get the test suite running from a fresh `bundle install && bundle exec rake spec`, so I haven't been able to verify it myself.

Do you know what ruby and gem versions the test suite will run against? 

