### PR TITLE
feature: Change to a Rails 4 ActiveModel validator.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -5,7 +5,7 @@
 
 == Description
 
-Extension to ActiveRecord::Base for validating hostnames and domain names.
+Validate hostnames and domain names in Rails.
 
 
 == Features
@@ -15,6 +15,8 @@ Extension to ActiveRecord::Base for validating hostnames and domain names.
 * Supports I18n for the error messages
 
 == Installation
+
+Requires Rails 4 or newer.
 
 As plugin (from master)
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ spec = Gem::Specification.new do |s|
   s.version                   = GEM_VERSION
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors                   = ["Kim Nørgaard"]
-  s.description               = 'Extension to ActiveRecord::Base for validating hostnames'
+  s.description               = 'Extension to validate hostnames in Rails'
   s.summary                   = 'Checks for valid hostnames'
   s.email                     = 'jasen@jasen.dk'
   s.extra_rdoc_files          = ["README.rdoc", "CHANGELOG.rdoc", "MIT-LICENSE"]
@@ -22,12 +22,8 @@ spec = Gem::Specification.new do |s|
   s.homepage                  = %q{https://github.com/KimNorgaard/validates_hostname}
   s.licenses                  = 'MIT'
   s.require_paths             = ["lib"]
-  s.add_runtime_dependency 'activerecord', '>= 3.0'
-  s.add_runtime_dependency 'activesupport', '>= 3.0'
+  s.add_runtime_dependency 'activemodel', '>= 4.0'
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'rails'
-  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rspec-collection_matchers'
 end

--- a/lib/validates_hostname.rb
+++ b/lib/validates_hostname.rb
@@ -1,168 +1,166 @@
-require 'active_support/concern'
-require 'active_record'
 require 'active_model'
 
-module PAK
-  module ValidatesHostname
-    autoload :VERSION, 'validates_hostname/version'
-
-    # List from IANA: http://www.iana.org/domains/root/db/
-    #                 http://data.iana.org/TLD/tlds-alpha-by-domain.txt
-    ALLOWED_TLDS = %w(
-      . aaa aarp abarth abb abbott abbvie abc able abogado abudhabi ac academy
-      accenture accountant accountants aco active actor ad adac ads adult ae aeg
-      aero aetna af afamilycompany afl africa ag agakhan agency ai aig aigo airbus
-      airforce airtel akdn al alfaromeo alibaba alipay allfinanz allstate ally
-      alsace alstom am americanexpress americanfamily amex amfam amica amsterdam
-      analytics android anquan anz ao aol apartments app apple aq aquarelle ar
-      aramco archi army arpa art arte as asda asia associates at athleta attorney
-      au auction audi audible audio auspost author auto autos avianca aw aws ax
-      axa az azure ba baby baidu banamex bananarepublic band bank bar barcelona
-      barclaycard barclays barefoot bargains baseball basketball bauhaus bayern bb
-      bbc bbt bbva bcg bcn bd be beats beauty beer bentley berlin best bestbuy bet
-      bf bg bh bharti bi bible bid bike bing bingo bio biz bj black blackfriday
-      blanco blockbuster blog bloomberg blue bm bms bmw bn bnl bnpparibas bo boats
-      boehringer bofa bom bond boo book booking boots bosch bostik boston bot
-      boutique box br bradesco bridgestone broadway broker brother brussels bs bt
-      budapest bugatti build builders business buy buzz bv bw by bz bzh ca cab
-      cafe cal call calvinklein cam camera camp cancerresearch canon capetown
-      capital capitalone car caravan cards care career careers cars cartier casa
-      case caseih cash casino cat catering catholic cba cbn cbre cbs cc cd ceb
-      center ceo cern cf cfa cfd cg ch chanel channel chase chat cheap chintai
-      chloe christmas chrome chrysler church ci cipriani circle cisco citadel citi
-      citic city cityeats ck cl claims cleaning click clinic clinique clothing
-      cloud club clubmed cm cn co coach codes coffee college cologne com comcast
-      commbank community company compare computer comsec condos construction
-      consulting contact contractors cooking cookingchannel cool coop corsica
-      country coupon coupons courses cr credit creditcard creditunion cricket
-      crown crs cruise cruises csc cu cuisinella cv cw cx cy cymru cyou cz dabur
-      dad dance data date dating datsun day dclk dds de deal dealer deals degree
-      delivery dell deloitte delta democrat dental dentist desi design dev dhl
-      diamonds diet digital direct directory discount discover dish diy dj dk dm
-      dnp do docs doctor dodge dog doha domains dot download drive dtv dubai duck
-      dunlop duns dupont durban dvag dvr dz earth eat ec eco edeka edu education
-      ee eg email emerck energy engineer engineering enterprises epost epson
-      equipment er ericsson erni es esq estate esurance et eu eurovision eus
-      events everbank exchange expert exposed express extraspace fage fail
-      fairwinds faith family fan fans farm farmers fashion fast fedex feedback
-      ferrari ferrero fi fiat fidelity fido film final finance financial fire
-      firestone firmdale fish fishing fit fitness fj fk flickr flights flir
-      florist flowers fly fm fo foo food foodnetwork football ford forex forsale
-      forum foundation fox fr free fresenius frl frogans frontdoor frontier ftr
-      fujitsu fujixerox fun fund furniture futbol fyi ga gal gallery gallo gallup
-      game games gap garden gb gbiz gd gdn ge gea gent genting george gf gg ggee
-      gh gi gift gifts gives giving gl glade glass gle global globo gm gmail gmbh
-      gmo gmx gn godaddy gold goldpoint golf goo goodhands goodyear goog google
-      gop got gov gp gq gr grainger graphics gratis green gripe group gs gt gu
-      guardian gucci guge guide guitars guru gw gy hair hamburg hangout haus hbo
-      hdfc hdfcbank health healthcare help helsinki here hermes hgtv hiphop
-      hisamitsu hitachi hiv hk hkt hm hn hockey holdings holiday homedepot
-      homegoods homes homesense honda honeywell horse hospital host hosting hot
-      hoteles hotels hotmail house how hr hsbc ht htc hu hughes hyatt hyundai ibm
-      icbc ice icu id ie ieee ifm ikano il im imamat imdb immo immobilien in
-      industries infiniti info ing ink institute insurance insure int intel
-      international intuit investments io ipiranga iq ir irish is iselect ismaili
-      ist istanbul it itau itv iveco iwc jaguar java jcb jcp je jeep jetzt jewelry
-      jio jlc jll jm jmp jnj jo jobs joburg jot joy jp jpmorgan jprs juegos
-      juniper kaufen kddi ke kerryhotels kerrylogistics kerryproperties kfh kg kh
-      ki kia kim kinder kindle kitchen kiwi km kn koeln komatsu kosher kp kpmg kpn
-      kr krd kred kuokgroup kw ky kyoto kz la lacaixa ladbrokes lamborghini lamer
-      lancaster lancia lancome land landrover lanxess lasalle lat latino latrobe
-      law lawyer lb lc lds lease leclerc lefrak legal lego lexus lgbt li liaison
-      lidl life lifeinsurance lifestyle lighting like lilly limited limo lincoln
-      linde link lipsy live living lixil lk loan loans locker locus loft lol
-      london lotte lotto love lpl lplfinancial lr ls lt ltd ltda lu lundbeck lupin
-      luxe luxury lv ly ma macys madrid maif maison makeup man management mango
-      market marketing markets marriott marshalls maserati mattel mba mc mcd
-      mcdonalds mckinsey md me med media meet melbourne meme memorial men menu meo
-      metlife mg mh miami microsoft mil mini mint mit mitsubishi mk ml mlb mls mm
-      mma mn mo mobi mobile mobily moda moe moi mom monash money monster montblanc
-      mopar mormon mortgage moscow moto motorcycles mov movie movistar mp mq mr ms
-      msd mt mtn mtpc mtr mu museum mutual mv mw mx my mz na nab nadex nagoya name
-      nationwide natura navy nba nc ne nec net netbank netflix network neustar new
-      newholland news next nextdirect nexus nf nfl ng ngo nhk ni nico nike nikon
-      ninja nissan nissay nl no nokia northwesternmutual norton now nowruz nowtv
-      np nr nra nrw ntt nu nyc nz obi observer off office okinawa olayan
-      olayangroup oldnavy ollo om omega one ong onl online onyourside ooo open
-      oracle orange org organic orientexpress origins osaka otsuka ott ovh pa page
-      pamperedchef panasonic panerai paris pars partners parts party passagens pay
-      pccw pe pet pf pfizer pg ph pharmacy philips phone photo photography photos
-      physio piaget pics pictet pictures pid pin ping pink pioneer pizza pk pl
-      place play playstation plumbing plus pm pn pnc pohl poker politie porn post
-      pr pramerica praxi press prime pro prod productions prof progressive promo
-      properties property protection pru prudential ps pt pub pw pwc py qa qpon
-      quebec quest qvc racing radio raid re read realestate realtor realty recipes
-      red redstone redumbrella rehab reise reisen reit reliance ren rent rentals
-      repair report republican rest restaurant review reviews rexroth rich
-      richardli ricoh rightathome ril rio rip rmit ro rocher rocks rodeo rogers
-      room rs rsvp ru rugby ruhr run rw rwe ryukyu sa saarland safe safety sakura
-      sale salon samsclub samsung sandvik sandvikcoromant sanofi sap sapo sarl sas
-      save saxo sb sbi sbs sc sca scb schaeffler schmidt scholarships school
-      schule schwarz science scjohnson scor scot sd se seat secure security seek
-      select sener services ses seven sew sex sexy sfr sg sh shangrila sharp shaw
-      shell shia shiksha shoes shop shopping shouji show showtime shriram si silk
-      sina singles site sj sk ski skin sky skype sl sling sm smart smile sn sncf
-      so soccer social softbank software sohu solar solutions song sony soy space
-      spiegel spot spreadbetting sr srl srt st stada staples star starhub
-      statebank statefarm statoil stc stcgroup stockholm storage store stream
-      studio study style su sucks supplies supply support surf surgery suzuki sv
-      swatch swiftcover swiss sx sy sydney symantec systems sz tab taipei talk
-      taobao target tatamotors tatar tattoo tax taxi tc tci td tdk team tech
-      technology tel telecity telefonica temasek tennis teva tf tg th thd theater
-      theatre tiaa tickets tienda tiffany tips tires tirol tj tjmaxx tjx tk tkmaxx
-      tl tm tmall tn to today tokyo tools top toray toshiba total tours town
-      toyota toys tr trade trading training travel travelchannel travelers
-      travelersinsurance trust trv tt tube tui tunes tushu tv tvs tw tz ua ubank
-      ubs uconnect ug uk unicom university uno uol ups us uy uz va vacations vana
-      vanguard vc ve vegas ventures verisign versicherung vet vg vi viajes video
-      vig viking villas vin vip virgin visa vision vista vistaprint viva vivo
-      vlaanderen vn vodka volkswagen volvo vote voting voto voyage vu vuelos wales
-      walmart walter wang wanggou warman watch watches weather weatherchannel
-      webcam weber website wed wedding weibo weir wf whoswho wien wiki williamhill
-      win windows wine winners wme wolterskluwer woodside work works world wow ws
-      wtc wtf xbox xerox xfinity xihuan xin xn--11b4c3d xn--1ck2e1b xn--1qqw23a
-      xn--30rr7y xn--3bst00m xn--3ds443g xn--3e0b707e xn--3oq18vl8pn36a xn--3pxu8k
-      xn--42c2d9a xn--45brj9c xn--45q11c xn--4gbrim xn--54b7fta0cc xn--55qw42g
-      xn--55qx5d xn--5su34j936bgsg xn--5tzm5g xn--6frz82g xn--6qq986b3xl
-      xn--80adxhks xn--80ao21a xn--80aqecdr1a xn--80asehdb xn--80aswg xn--8y0a063a
-      xn--90a3ac xn--90ae xn--90ais xn--9dbq2a xn--9et52u xn--9krt00a
-      xn--b4w605ferd xn--bck1b9a5dre4c xn--c1avg xn--c2br7g xn--cck2b3b xn--cg4bki
-      xn--clchc0ea0b2g2a9gcd xn--czr694b xn--czrs0t xn--czru2d xn--d1acj3b
-      xn--d1alf xn--e1a4c xn--eckvdtc9d xn--efvy88h xn--estv75g xn--fct429k
-      xn--fhbei xn--fiq228c5hs xn--fiq64b xn--fiqs8s xn--fiqz9s xn--fjq720a
-      xn--flw351e xn--fpcrj9c3d xn--fzc2c9e2c xn--fzys8d69uvgm xn--g2xx48c
-      xn--gckr3f0f xn--gecrj9c xn--gk3at1e xn--h2brj9c xn--hxt814e xn--i1b6b1a6a2e
-      xn--imr513n xn--io0a7i xn--j1aef xn--j1amh xn--j6w193g xn--jlq61u9w7b
-      xn--jvr189m xn--kcrx77d1x4a xn--kprw13d xn--kpry57d xn--kpu716f xn--kput3i
-      xn--l1acc xn--lgbbat1ad8j xn--mgb9awbf xn--mgba3a3ejt xn--mgba3a4f16a
-      xn--mgba7c0bbn0a xn--mgbaam7a8h xn--mgbab2bd xn--mgbai9azgqp6j
-      xn--mgbayh7gpa xn--mgbb9fbpob xn--mgbbh1a71e xn--mgbc0a9azcg xn--mgbca7dzdo
-      xn--mgberp4a5d4ar xn--mgbi4ecexp xn--mgbpl2fh xn--mgbt3dhd xn--mgbtx2b
-      xn--mgbx4cd0ab xn--mix891f xn--mk1bu44c xn--mxtq1m xn--ngbc5azd xn--ngbe9e0a
-      xn--node xn--nqv7f xn--nqv7fs00ema xn--nyqy26a xn--o3cw4h xn--ogbpf8fl
-      xn--p1acf xn--p1ai xn--pbt977c xn--pgbs0dh xn--pssy2u xn--q9jyb4c
-      xn--qcka1pmc xn--qxam xn--rhqv96g xn--rovu88b xn--s9brj9c xn--ses554g
-      xn--t60b56a xn--tckwe xn--tiq49xqyj xn--unup4y xn--vermgensberater-ctb
-      xn--vermgensberatung-pwb xn--vhquv xn--vuq861b xn--w4r85el8fhu5dnra
-      xn--w4rs40l xn--wgbh1c xn--wgbl6a xn--xhq521b xn--xkc2al3hye2a
-      xn--xkc2dl3a5ee0h xn--y9a3aq xn--yfro4i67o xn--ygbi2ammx xn--zfr164b xperia
-      xxx xyz yachts yahoo yamaxun yandex ye yodobashi yoga yokohama you youtube
-      yt yun za zappos zara zero zip zippo zm zone zuerich zw
-    )
-
-    DEFAULT_ERROR_MSG = {
-      :invalid_hostname_length            => 'must be between 1 and 255 characters long',
-      :invalid_label_length               => 'must be between 1 and 63 characters long',
-      :label_begins_or_ends_with_hyphen   => 'begins or ends with hyphen',
-      :label_contains_invalid_characters  => "contains invalid characters (valid characters: [%{valid_chars}])",
-      :hostname_label_is_numeric          => 'unqualified hostname part cannot consist of numeric values only',
-      :hostname_is_not_fqdn               => 'is not a fully qualified domain name',
-      :single_numeric_hostname_label      => 'cannot consist of a single numeric label',
-      :hostname_contains_consecutive_dots => 'must not contain consecutive dots',
-      :hostname_ends_with_dot             => 'must not end with a dot'
-    }.freeze
-
+module ActiveModel
+  module Validations
     class HostnameValidator < ActiveModel::EachValidator
+      autoload :VERSION, 'validates_hostname/version'
+
+      # List from IANA: http://www.iana.org/domains/root/db/
+      #                 http://data.iana.org/TLD/tlds-alpha-by-domain.txt
+      ALLOWED_TLDS = %w(
+        . aaa aarp abarth abb abbott abbvie abc able abogado abudhabi ac academy
+        accenture accountant accountants aco active actor ad adac ads adult ae aeg
+        aero aetna af afamilycompany afl africa ag agakhan agency ai aig aigo airbus
+        airforce airtel akdn al alfaromeo alibaba alipay allfinanz allstate ally
+        alsace alstom am americanexpress americanfamily amex amfam amica amsterdam
+        analytics android anquan anz ao aol apartments app apple aq aquarelle ar
+        aramco archi army arpa art arte as asda asia associates at athleta attorney
+        au auction audi audible audio auspost author auto autos avianca aw aws ax
+        axa az azure ba baby baidu banamex bananarepublic band bank bar barcelona
+        barclaycard barclays barefoot bargains baseball basketball bauhaus bayern bb
+        bbc bbt bbva bcg bcn bd be beats beauty beer bentley berlin best bestbuy bet
+        bf bg bh bharti bi bible bid bike bing bingo bio biz bj black blackfriday
+        blanco blockbuster blog bloomberg blue bm bms bmw bn bnl bnpparibas bo boats
+        boehringer bofa bom bond boo book booking boots bosch bostik boston bot
+        boutique box br bradesco bridgestone broadway broker brother brussels bs bt
+        budapest bugatti build builders business buy buzz bv bw by bz bzh ca cab
+        cafe cal call calvinklein cam camera camp cancerresearch canon capetown
+        capital capitalone car caravan cards care career careers cars cartier casa
+        case caseih cash casino cat catering catholic cba cbn cbre cbs cc cd ceb
+        center ceo cern cf cfa cfd cg ch chanel channel chase chat cheap chintai
+        chloe christmas chrome chrysler church ci cipriani circle cisco citadel citi
+        citic city cityeats ck cl claims cleaning click clinic clinique clothing
+        cloud club clubmed cm cn co coach codes coffee college cologne com comcast
+        commbank community company compare computer comsec condos construction
+        consulting contact contractors cooking cookingchannel cool coop corsica
+        country coupon coupons courses cr credit creditcard creditunion cricket
+        crown crs cruise cruises csc cu cuisinella cv cw cx cy cymru cyou cz dabur
+        dad dance data date dating datsun day dclk dds de deal dealer deals degree
+        delivery dell deloitte delta democrat dental dentist desi design dev dhl
+        diamonds diet digital direct directory discount discover dish diy dj dk dm
+        dnp do docs doctor dodge dog doha domains dot download drive dtv dubai duck
+        dunlop duns dupont durban dvag dvr dz earth eat ec eco edeka edu education
+        ee eg email emerck energy engineer engineering enterprises epost epson
+        equipment er ericsson erni es esq estate esurance et eu eurovision eus
+        events everbank exchange expert exposed express extraspace fage fail
+        fairwinds faith family fan fans farm farmers fashion fast fedex feedback
+        ferrari ferrero fi fiat fidelity fido film final finance financial fire
+        firestone firmdale fish fishing fit fitness fj fk flickr flights flir
+        florist flowers fly fm fo foo food foodnetwork football ford forex forsale
+        forum foundation fox fr free fresenius frl frogans frontdoor frontier ftr
+        fujitsu fujixerox fun fund furniture futbol fyi ga gal gallery gallo gallup
+        game games gap garden gb gbiz gd gdn ge gea gent genting george gf gg ggee
+        gh gi gift gifts gives giving gl glade glass gle global globo gm gmail gmbh
+        gmo gmx gn godaddy gold goldpoint golf goo goodhands goodyear goog google
+        gop got gov gp gq gr grainger graphics gratis green gripe group gs gt gu
+        guardian gucci guge guide guitars guru gw gy hair hamburg hangout haus hbo
+        hdfc hdfcbank health healthcare help helsinki here hermes hgtv hiphop
+        hisamitsu hitachi hiv hk hkt hm hn hockey holdings holiday homedepot
+        homegoods homes homesense honda honeywell horse hospital host hosting hot
+        hoteles hotels hotmail house how hr hsbc ht htc hu hughes hyatt hyundai ibm
+        icbc ice icu id ie ieee ifm ikano il im imamat imdb immo immobilien in
+        industries infiniti info ing ink institute insurance insure int intel
+        international intuit investments io ipiranga iq ir irish is iselect ismaili
+        ist istanbul it itau itv iveco iwc jaguar java jcb jcp je jeep jetzt jewelry
+        jio jlc jll jm jmp jnj jo jobs joburg jot joy jp jpmorgan jprs juegos
+        juniper kaufen kddi ke kerryhotels kerrylogistics kerryproperties kfh kg kh
+        ki kia kim kinder kindle kitchen kiwi km kn koeln komatsu kosher kp kpmg kpn
+        kr krd kred kuokgroup kw ky kyoto kz la lacaixa ladbrokes lamborghini lamer
+        lancaster lancia lancome land landrover lanxess lasalle lat latino latrobe
+        law lawyer lb lc lds lease leclerc lefrak legal lego lexus lgbt li liaison
+        lidl life lifeinsurance lifestyle lighting like lilly limited limo lincoln
+        linde link lipsy live living lixil lk loan loans locker locus loft lol
+        london lotte lotto love lpl lplfinancial lr ls lt ltd ltda lu lundbeck lupin
+        luxe luxury lv ly ma macys madrid maif maison makeup man management mango
+        market marketing markets marriott marshalls maserati mattel mba mc mcd
+        mcdonalds mckinsey md me med media meet melbourne meme memorial men menu meo
+        metlife mg mh miami microsoft mil mini mint mit mitsubishi mk ml mlb mls mm
+        mma mn mo mobi mobile mobily moda moe moi mom monash money monster montblanc
+        mopar mormon mortgage moscow moto motorcycles mov movie movistar mp mq mr ms
+        msd mt mtn mtpc mtr mu museum mutual mv mw mx my mz na nab nadex nagoya name
+        nationwide natura navy nba nc ne nec net netbank netflix network neustar new
+        newholland news next nextdirect nexus nf nfl ng ngo nhk ni nico nike nikon
+        ninja nissan nissay nl no nokia northwesternmutual norton now nowruz nowtv
+        np nr nra nrw ntt nu nyc nz obi observer off office okinawa olayan
+        olayangroup oldnavy ollo om omega one ong onl online onyourside ooo open
+        oracle orange org organic orientexpress origins osaka otsuka ott ovh pa page
+        pamperedchef panasonic panerai paris pars partners parts party passagens pay
+        pccw pe pet pf pfizer pg ph pharmacy philips phone photo photography photos
+        physio piaget pics pictet pictures pid pin ping pink pioneer pizza pk pl
+        place play playstation plumbing plus pm pn pnc pohl poker politie porn post
+        pr pramerica praxi press prime pro prod productions prof progressive promo
+        properties property protection pru prudential ps pt pub pw pwc py qa qpon
+        quebec quest qvc racing radio raid re read realestate realtor realty recipes
+        red redstone redumbrella rehab reise reisen reit reliance ren rent rentals
+        repair report republican rest restaurant review reviews rexroth rich
+        richardli ricoh rightathome ril rio rip rmit ro rocher rocks rodeo rogers
+        room rs rsvp ru rugby ruhr run rw rwe ryukyu sa saarland safe safety sakura
+        sale salon samsclub samsung sandvik sandvikcoromant sanofi sap sapo sarl sas
+        save saxo sb sbi sbs sc sca scb schaeffler schmidt scholarships school
+        schule schwarz science scjohnson scor scot sd se seat secure security seek
+        select sener services ses seven sew sex sexy sfr sg sh shangrila sharp shaw
+        shell shia shiksha shoes shop shopping shouji show showtime shriram si silk
+        sina singles site sj sk ski skin sky skype sl sling sm smart smile sn sncf
+        so soccer social softbank software sohu solar solutions song sony soy space
+        spiegel spot spreadbetting sr srl srt st stada staples star starhub
+        statebank statefarm statoil stc stcgroup stockholm storage store stream
+        studio study style su sucks supplies supply support surf surgery suzuki sv
+        swatch swiftcover swiss sx sy sydney symantec systems sz tab taipei talk
+        taobao target tatamotors tatar tattoo tax taxi tc tci td tdk team tech
+        technology tel telecity telefonica temasek tennis teva tf tg th thd theater
+        theatre tiaa tickets tienda tiffany tips tires tirol tj tjmaxx tjx tk tkmaxx
+        tl tm tmall tn to today tokyo tools top toray toshiba total tours town
+        toyota toys tr trade trading training travel travelchannel travelers
+        travelersinsurance trust trv tt tube tui tunes tushu tv tvs tw tz ua ubank
+        ubs uconnect ug uk unicom university uno uol ups us uy uz va vacations vana
+        vanguard vc ve vegas ventures verisign versicherung vet vg vi viajes video
+        vig viking villas vin vip virgin visa vision vista vistaprint viva vivo
+        vlaanderen vn vodka volkswagen volvo vote voting voto voyage vu vuelos wales
+        walmart walter wang wanggou warman watch watches weather weatherchannel
+        webcam weber website wed wedding weibo weir wf whoswho wien wiki williamhill
+        win windows wine winners wme wolterskluwer woodside work works world wow ws
+        wtc wtf xbox xerox xfinity xihuan xin xn--11b4c3d xn--1ck2e1b xn--1qqw23a
+        xn--30rr7y xn--3bst00m xn--3ds443g xn--3e0b707e xn--3oq18vl8pn36a xn--3pxu8k
+        xn--42c2d9a xn--45brj9c xn--45q11c xn--4gbrim xn--54b7fta0cc xn--55qw42g
+        xn--55qx5d xn--5su34j936bgsg xn--5tzm5g xn--6frz82g xn--6qq986b3xl
+        xn--80adxhks xn--80ao21a xn--80aqecdr1a xn--80asehdb xn--80aswg xn--8y0a063a
+        xn--90a3ac xn--90ae xn--90ais xn--9dbq2a xn--9et52u xn--9krt00a
+        xn--b4w605ferd xn--bck1b9a5dre4c xn--c1avg xn--c2br7g xn--cck2b3b xn--cg4bki
+        xn--clchc0ea0b2g2a9gcd xn--czr694b xn--czrs0t xn--czru2d xn--d1acj3b
+        xn--d1alf xn--e1a4c xn--eckvdtc9d xn--efvy88h xn--estv75g xn--fct429k
+        xn--fhbei xn--fiq228c5hs xn--fiq64b xn--fiqs8s xn--fiqz9s xn--fjq720a
+        xn--flw351e xn--fpcrj9c3d xn--fzc2c9e2c xn--fzys8d69uvgm xn--g2xx48c
+        xn--gckr3f0f xn--gecrj9c xn--gk3at1e xn--h2brj9c xn--hxt814e xn--i1b6b1a6a2e
+        xn--imr513n xn--io0a7i xn--j1aef xn--j1amh xn--j6w193g xn--jlq61u9w7b
+        xn--jvr189m xn--kcrx77d1x4a xn--kprw13d xn--kpry57d xn--kpu716f xn--kput3i
+        xn--l1acc xn--lgbbat1ad8j xn--mgb9awbf xn--mgba3a3ejt xn--mgba3a4f16a
+        xn--mgba7c0bbn0a xn--mgbaam7a8h xn--mgbab2bd xn--mgbai9azgqp6j
+        xn--mgbayh7gpa xn--mgbb9fbpob xn--mgbbh1a71e xn--mgbc0a9azcg xn--mgbca7dzdo
+        xn--mgberp4a5d4ar xn--mgbi4ecexp xn--mgbpl2fh xn--mgbt3dhd xn--mgbtx2b
+        xn--mgbx4cd0ab xn--mix891f xn--mk1bu44c xn--mxtq1m xn--ngbc5azd xn--ngbe9e0a
+        xn--node xn--nqv7f xn--nqv7fs00ema xn--nyqy26a xn--o3cw4h xn--ogbpf8fl
+        xn--p1acf xn--p1ai xn--pbt977c xn--pgbs0dh xn--pssy2u xn--q9jyb4c
+        xn--qcka1pmc xn--qxam xn--rhqv96g xn--rovu88b xn--s9brj9c xn--ses554g
+        xn--t60b56a xn--tckwe xn--tiq49xqyj xn--unup4y xn--vermgensberater-ctb
+        xn--vermgensberatung-pwb xn--vhquv xn--vuq861b xn--w4r85el8fhu5dnra
+        xn--w4rs40l xn--wgbh1c xn--wgbl6a xn--xhq521b xn--xkc2al3hye2a
+        xn--xkc2dl3a5ee0h xn--y9a3aq xn--yfro4i67o xn--ygbi2ammx xn--zfr164b xperia
+        xxx xyz yachts yahoo yamaxun yandex ye yodobashi yoga yokohama you youtube
+        yt yun za zappos zara zero zip zippo zm zone zuerich zw
+      ).freeze
+
+      DEFAULT_ERROR_MSG = {
+        :invalid_hostname_length            => 'must be between 1 and 255 characters long',
+        :invalid_label_length               => 'must be between 1 and 63 characters long',
+        :label_begins_or_ends_with_hyphen   => 'begins or ends with hyphen',
+        :label_contains_invalid_characters  => "contains invalid characters (valid characters: [%{valid_chars}])",
+        :hostname_label_is_numeric          => 'unqualified hostname part cannot consist of numeric values only',
+        :hostname_is_not_fqdn               => 'is not a fully qualified domain name',
+        :single_numeric_hostname_label      => 'cannot consist of a single numeric label',
+        :hostname_contains_consecutive_dots => 'must not contain consecutive dots',
+        :hostname_ends_with_dot             => 'must not end with a dot'
+      }.freeze
+
       def initialize(options)
         opts = {
           :allow_underscore        => false,
@@ -297,5 +295,3 @@ module PAK
     end
   end
 end
-
-ActiveRecord::Base.send(:include, PAK::ValidatesHostname)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,5 @@
-require 'active_record'
-require "rails/all"
-require 'rspec/rails'
+require 'rspec'
 require 'rspec/collection_matchers'
-
 require 'validates_hostname'
 require 'test_model'
 

--- a/spec/test_model.rb
+++ b/spec/test_model.rb
@@ -1,50 +1,72 @@
-class Record < ActiveRecord::Base
+class Record
+  include ActiveModel::Model
+  include ActiveModel::Validations
+  
+  # Convenience method hosited from rspec-railsa
+  def errors_on(attribute, options = {})
+    self.valid?(options[:context])
+    [self.errors[attribute]].flatten.compact
+  end
+  
+  attr_accessor :name
   validates :name,
             :hostname => true
 
+  attr_accessor :name_with_underscores
   validates :name_with_underscores,
             :hostname => { :allow_underscore => true }
 
+  attr_accessor :name_with_wildcard
   validates :name_with_wildcard,
             :hostname => { :allow_wildcard_hostname => true }
 
+  attr_accessor :name_with_numeric_hostname
   validates :name_with_numeric_hostname,
             :hostname => { :allow_numeric_hostname => true }
 
+  attr_accessor :name_with_blank
   validates :name_with_blank,
             :hostname => true,
             :allow_blank => true
 
+  attr_accessor :name_with_nil
   validates :name_with_nil,
             :hostname => true,
             :allow_nil => true
 
+  attr_accessor :name_with_valid_tld
   validates :name_with_valid_tld,
             :hostname => { :require_valid_tld => true }
 
+  attr_accessor :name_with_test_tld
   validates :name_with_test_tld,
             :hostname => { :require_valid_tld => true, :valid_tlds => %w(test) }
 
+  attr_accessor :name_with_valid_root_label
   validates :name_with_valid_root_label,
             :hostname => { :allow_root_label => true },
             :allow_nil => true,
             :allow_blank => true
 
+  attr_accessor :name_with_invalid_root_label
   validates :name_with_invalid_root_label,
             :hostname => true,
             :allow_nil => true,
             :allow_blank => true
 
+  attr_accessor :domainname_with_numeric_hostname
   validates :domainname_with_numeric_hostname,
             :domainname => true,
             :allow_nil => true,
             :allow_blank => true
 
+  attr_accessor :domainname_with_valid_root_label
   validates :domainname_with_valid_root_label,
             :domainname => { :allow_root_label => true },
             :allow_nil => true,
             :allow_blank => true
 
+  attr_accessor :domainname_with_invalid_root_label
   validates :domainname_with_invalid_root_label,
             :domainname => true,
             :allow_nil => true,

--- a/spec/validates_hostname_spec.rb
+++ b/spec/validates_hostname_spec.rb
@@ -1,33 +1,7 @@
 require 'spec_helper'
 
-ActiveRecord::Base.establish_connection :adapter => 'sqlite3', :database => ':memory:'
-
-# Silence schema load
-ActiveRecord::Schema.verbose = false
-
 describe Record do
-  before(:all) do
-    ActiveRecord::Base.connection.data_sources.each { |source| ActiveRecord::Base.connection.drop_table(source) }
-    ActiveRecord::Schema.define(:version => 1) do
-      create_table :records do |t|
-        t.string   :name
-        t.string   :name_with_underscores
-        t.string   :name_with_wildcard
-        t.string   :name_with_valid_tld
-        t.string   :name_with_test_tld
-        t.string   :name_with_numeric_hostname
-        t.string   :name_with_blank
-        t.string   :name_with_nil
-        t.string   :name_with_valid_root_label
-        t.string   :name_with_invalid_root_label
-        t.string   :domainname_with_numeric_hostname
-        t.string   :domainname_with_valid_root_label
-        t.string   :domainname_with_invalid_root_label
-      end
-    end
-  end
-
-  it "should save with valid hostnames" do
+  it "should be valid with valid hostnames" do
     record = Record.new :name                       => 'test',
                         :name_with_underscores      => 'test',
                         :name_with_wildcard         => 'test.org',
@@ -36,10 +10,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should save with hostnames with hyphens" do
+  it "should be valid with hostnames with hyphens" do
     record = Record.new :name                       => 't-est',
                         :name_with_underscores      => 't-est',
                         :name_with_wildcard         => 't-est.org',
@@ -48,10 +22,10 @@ describe Record do
                         :name_with_numeric_hostname => 't-est',
                         :name_with_blank            => 't-est',
                         :name_with_nil              => 't-est'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should save with hostnames with underscores if option is true" do
+  it "should be valid with hostnames with underscores if option is true" do
     record = Record.new :name_with_underscores      => '_test',
                         :name_with_wildcard         => 'test.org',
                         :name                       => 'test',
@@ -60,10 +34,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should not save with hostnames with underscores if option is false" do
+  it "should not be valid with hostnames with underscores if option is false" do
     record = Record.new :name_with_underscores      => '_test',
                         :name_with_wildcard         => '_test.org',
                         :name                       => '_test',
@@ -72,7 +46,7 @@ describe Record do
                         :name_with_numeric_hostname => '_test',
                         :name_with_blank            => '_test',
                         :name_with_nil              => '_test'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
 
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_valid_tld)
@@ -83,7 +57,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_nil)
   end
 
-  it "should save with hostnames with wildcard if option is true" do
+  it "should be valid with hostnames with wildcard if option is true" do
     record = Record.new :name                       => 'test',
                         :name_with_wildcard         => '*.test.org',
                         :name_with_underscores      => 'test.org',
@@ -92,10 +66,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should not save with hostnames with wildcard if option is false" do
+  it "should not be valid with hostnames with wildcard if option is false" do
     record = Record.new :name                       => '*.test',
                         :name_with_wildcard         => '*.test.org',
                         :name_with_underscores      => '*.test',
@@ -104,7 +78,7 @@ describe Record do
                         :name_with_numeric_hostname => '*.test',
                         :name_with_blank            => '*.test',
                         :name_with_nil              => '*.test'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
 
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
@@ -115,7 +89,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_nil)
   end
 
-  it "should save with blank hostname" do
+  it "should be valid with blank hostname" do
     record = Record.new :name_with_blank            => '',
                         :name                       => 'test',
                         :name_with_wildcard         => 'test.org',
@@ -124,10 +98,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_underscores      => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should not save with blank hostname" do
+  it "should not be valid with blank hostname" do
     record = Record.new :name                       => '',
                         :name_with_underscores      => '',
                         :name_with_wildcard         => '',
@@ -136,7 +110,7 @@ describe Record do
                         :name_with_numeric_hostname => '',
                         :name_with_nil              => '',
                         :name_with_blank            => ''
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
     record.should have_at_least(1).errors_on(:name_with_wildcard)
@@ -146,7 +120,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_nil)
   end
 
-  it "should save with nil hostname" do
+  it "should be valid with nil hostname" do
     record = Record.new :name_with_nil              => nil,
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -155,10 +129,10 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should save when domain name length between 64 and 255" do
+  it "should be valid when domain name length between 64 and 255" do
     long_labels = (('t' * 60) + '.' + ('t' * 60))
     record = Record.new :name                       => long_labels,
                         :name_with_underscores      => long_labels,
@@ -168,10 +142,10 @@ describe Record do
                         :name_with_numeric_hostname => long_labels,
                         :name_with_blank            => long_labels,
                         :name_with_nil              => long_labels
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should not save with too long hostname" do
+  it "should not be valid with too long hostname" do
     longname=('t' * 256)
     record = Record.new :name                       => longname,
                         :name_with_underscores      => longname,
@@ -181,7 +155,7 @@ describe Record do
                         :name_with_numeric_hostname => longname,
                         :name_with_blank            => longname,
                         :name_with_nil              => longname
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
     record.should have_at_least(1).errors_on(:name_with_wildcard)
@@ -192,7 +166,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_nil)
   end
 
-  it "should not save with too long hostname label" do
+  it "should not be valid with too long hostname label" do
     long_labels = (('t' * 64) + '.' + ('t' * 64))
     record = Record.new :name                       => long_labels,
                         :name_with_underscores      => long_labels,
@@ -202,7 +176,7 @@ describe Record do
                         :name_with_numeric_hostname => long_labels,
                         :name_with_blank            => long_labels,
                         :name_with_nil              => long_labels
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
   end
 
@@ -218,7 +192,7 @@ describe Record do
       record.name_with_numeric_hostname = testname
       record.name_with_blank            = testname
       record.name_with_nil              = testname
-      record.save.should_not be_truthy
+      record.valid?.should_not be_truthy
       record.should have_at_least(1).errors_on(:name)
       record.should have_at_least(1).errors_on(:name_with_underscores)
       record.should have_at_least(1).errors_on(:name_with_wildcard)
@@ -230,7 +204,7 @@ describe Record do
     end
   end
 
-  it "should not save with hostname labels beginning with a hyphen" do
+  it "should not be valid with hostname labels beginning with a hyphen" do
     record = Record.new :name                       => '-test',
                         :name_with_underscores      => '-test',
                         :name_with_wildcard         => '-test',
@@ -239,7 +213,7 @@ describe Record do
                         :name_with_numeric_hostname => '-test',
                         :name_with_blank            => '-test',
                         :name_with_nil              => '-test'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
     record.should have_at_least(1).errors_on(:name_with_wildcard)
@@ -250,7 +224,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_nil)
   end
 
-  it "should not save with hostname labels ending with a hyphen" do
+  it "should not be valid with hostname labels ending with a hyphen" do
     record = Record.new :name                       => 'test-',
                         :name_with_underscores      => 'test-',
                         :name_with_wildcard         => 'test-',
@@ -259,7 +233,7 @@ describe Record do
                         :name_with_numeric_hostname => 'test-',
                         :name_with_blank            => 'test-',
                         :name_with_nil              => 'test-'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
     record.should have_at_least(1).errors_on(:name_with_wildcard)
@@ -270,7 +244,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_nil)
   end
 
-  it "should not save hostnames with numeric only hostname labels" do
+  it "should not be valid hostnames with numeric only hostname labels" do
     record = Record.new :name                       => '12345',
                         :name_with_underscores      => '12345',
                         :name_with_wildcard         => '12345',
@@ -279,7 +253,7 @@ describe Record do
                         :name_with_numeric_hostname => '0x12345',
                         :name_with_blank            => '12345',
                         :name_with_nil              => '12345'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
     record.should have_at_least(1).errors_on(:name_with_wildcard)
@@ -289,7 +263,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_nil)
   end
 
-  it "should save hostnames with numeric only hostname labels if option is true" do
+  it "should be valid hostnames with numeric only hostname labels if option is true" do
     record = Record.new :name_with_numeric_hostname => '12345',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -298,10 +272,10 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should not save hostnames with invalid tld if option is true" do
+  it "should not be valid hostnames with invalid tld if option is true" do
     record = Record.new :name_with_valid_tld        => 'test.invalidtld',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -310,11 +284,11 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name_with_valid_tld)
   end
 
-  it "should save hostnames with valid tld if option is true" do
+  it "should be valid hostnames with valid tld if option is true" do
     record = Record.new :name_with_valid_tld        => 'test.org',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -323,10 +297,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should save hostnames with invalid tld if option is false" do
+  it "should be valid hostnames with invalid tld if option is false" do
     record = Record.new :name                       => 'test.invalidtld',
                         :name_with_underscores      => 'test.invalidtld',
                         :name_with_wildcard         => 'test.invalidtld',
@@ -335,10 +309,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test.invalidtld',
                         :name_with_blank            => 'test.invalidtld',
                         :name_with_nil              => 'test.invalidtld'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should save hostnames with tld from list" do
+  it "should be valid hostnames with tld from list" do
     record = Record.new :name_with_test_tld         => 'test.test',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -347,10 +321,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should not save hostnames with invalid tld from list" do
+  it "should not be valid hostnames with invalid tld from list" do
     record = Record.new :name_with_test_tld         => 'test.invalidtld',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -359,11 +333,11 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name_with_test_tld)
   end
 
-  it "should not save domainnames with single numeric hostname labels" do
+  it "should not be valid domainnames with single numeric hostname labels" do
     record = Record.new :domainname_with_numeric_hostname => '12345',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -373,11 +347,11 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:domainname_with_numeric_hostname)
   end
 
-  it "should save domainnames with numeric hostname labels" do
+  it "should be valid domainnames with numeric hostname labels" do
     record = Record.new :domainname_with_numeric_hostname => '12345.org',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -387,10 +361,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should not save hostnames containing consecutive dots" do
+  it "should not be valid hostnames containing consecutive dots" do
     record = Record.new :name                       => 'te...st',
                         :name_with_underscores      => 'test',
                         :name_with_wildcard         => 'test',
@@ -399,11 +373,11 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
   end
 
-  it "should save hostnames with trailing dot if option is true" do
+  it "should be valid hostnames with trailing dot if option is true" do
     record = Record.new :name_with_valid_root_label => 'test.org.',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -413,10 +387,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should not save hostnames with trailing dot if option is false" do
+  it "should not be valid hostnames with trailing dot if option is false" do
     record = Record.new :name_with_invalid_root_label => 'test.org.',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -426,11 +400,11 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name_with_invalid_root_label)
   end
 
-  it "should save hostnames consisting of a single dot if option is true" do
+  it "should be valid hostnames consisting of a single dot if option is true" do
     record = Record.new :name_with_valid_root_label => '.',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -440,10 +414,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should not save hostnames consisting of a single dot" do
+  it "should not be valid hostnames consisting of a single dot" do
     record = Record.new :name_with_invalid_root_label => '.',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -453,11 +427,11 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:name_with_invalid_root_label)
   end
 
-  it "should save domainnames consisting of a single dot if option is true" do
+  it "should be valid domainnames consisting of a single dot if option is true" do
     record = Record.new :domainname_with_valid_root_label => '.',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -467,10 +441,10 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should be_truthy
+    record.valid?.should be_truthy
   end
 
-  it "should not save domainnames consisting of a single dot" do
+  it "should not be valid domainnames consisting of a single dot" do
     record = Record.new :domainname_with_invalid_root_label => '.',
                         :name                       => 'test',
                         :name_with_underscores      => 'test',
@@ -480,7 +454,7 @@ describe Record do
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
                         :name_with_nil              => 'test'
-    record.save.should_not be_truthy
+    record.valid?.should_not be_truthy
     record.should have_at_least(1).errors_on(:domainname_with_invalid_root_label)
   end
 


### PR DESCRIPTION
Closes #10 

Rails 4 introduced ActiveModel, ActiveModel::Validations and ActiveModel::EachValidator. Instead of injecting ourselves into ActiveRecord::Base, we will be automatically picked up.

We can now also be used on ActiveModel as well as ActiveRecord. This simplifies testing.

This does mean it requires at least Rails 4. If that's unacceptable I can add a shim for Rails 3.

Also
* rspec-rails was dropped because it seems to want all of Rails loaded.
  We only needed one convenience method, errors_on. It has been copied into our test model.
* Bumped our runtime dependency to activemodel >= 4.0. Dropped the others.
* Dropped the development dependency on all of Rails. We only need ActiveModel.