### PR TITLE
allow for conditional validation, controlled with model method

### DIFF
--- a/lib/validates_hostname.rb
+++ b/lib/validates_hostname.rb
@@ -210,7 +210,9 @@ module PAK
 
           # CHECK 5: in order to be fully qualified, the full hostname's
           #          TLD must be valid
-          if options[:require_valid_tld] == true
+          require_valid_tld = options[:require_valid_tld]
+          require_valid_tld = record.send(require_valid_tld) if require_valid_tld.is_a?(Symbol)
+          if require_valid_tld
             my_tld = value == '.' ? value : labels.last
             my_tld ||= ''
             has_tld = options[:valid_tlds].select {

--- a/lib/validates_hostname/version.rb
+++ b/lib/validates_hostname/version.rb
@@ -1,5 +1,5 @@
 module PAK
   module ValidatesHostname
-    VERSION = '1.0.11'
+    VERSION = '1.0.12'
   end
 end

--- a/validates_hostname.gemspec
+++ b/validates_hostname.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: validates_hostname 1.0.11 ruby lib
+# stub: validates_hostname 1.0.12 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "validates_hostname".freeze
-  s.version = "1.0.11"
+  s.version = "1.0.12"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]


### PR DESCRIPTION
we need to have valid tlds, but we also need to allow `.local` tld. 

this PR opens functionality to have a validation like this

```

validates :base_domain, presence: true, hostname: { require_valid_tld: :valid_tld_required? }

  def valid_tld_required?
    !base_domain.end_with?(".local")
  end

```