### PR TITLE
Fix typo in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -88,7 +88,7 @@ With options
 Without options
 
   class Record < ActiveRecord::Base
-    validates :host, :hostname => true
+    validates :name, :hostname => true
   end
 
   >> @record = Record.new :name => 'horse'


### PR DESCRIPTION
When reading through the docs, I noticed a typo in the example. This PR addresses this.