### PR TITLE
Respect given error message

### DIFF
--- a/lib/validates_hostname.rb
+++ b/lib/validates_hostname.rb
@@ -241,7 +241,7 @@ module PAK
 
       def add_error(record, attr_name, message, *interpolators)
         args = {
-          :default => [DEFAULT_ERROR_MSG[message], options[:message]],
+          :default => [options[:message], DEFAULT_ERROR_MSG[message]].compact,
           :scope   => [:errors, :messages]
         }.merge(interpolators.last.is_a?(Hash) ? interpolators.pop : {})
         record.errors.add(attr_name, I18n.t( message, **args ))
@@ -275,7 +275,7 @@ module PAK
 
       def add_error(record, attr_name, message, *interpolators)
         args = {
-          :default => [DEFAULT_ERROR_MSG[message], options[:message]],
+          :default => [options[:message], DEFAULT_ERROR_MSG[message]].compact,
           :scope   => [:errors, :messages]
         }.merge(interpolators.last.is_a?(Hash) ? interpolators.pop : {})
         record.errors.add(attr_name, I18n.t( message, **args ))

--- a/spec/test_model.rb
+++ b/spec/test_model.rb
@@ -19,6 +19,9 @@ class Record < ActiveRecord::Base
             :hostname => true,
             :allow_nil => true
 
+  validates :name_with_message,
+            :hostname => { :message => 'test' }
+
   validates :name_with_valid_tld,
             :hostname => { :require_valid_tld => true }
 

--- a/spec/validates_hostname_spec.rb
+++ b/spec/validates_hostname_spec.rb
@@ -18,6 +18,7 @@ describe Record do
         t.string   :name_with_numeric_hostname
         t.string   :name_with_blank
         t.string   :name_with_nil
+        t.string   :name_with_message
         t.string   :name_with_valid_root_label
         t.string   :name_with_invalid_root_label
         t.string   :domainname_with_numeric_hostname
@@ -35,7 +36,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -47,7 +49,8 @@ describe Record do
                         :name_with_test_tld         => 't-test.test',
                         :name_with_numeric_hostname => 't-est',
                         :name_with_blank            => 't-est',
-                        :name_with_nil              => 't-est'
+                        :name_with_nil              => 't-est',
+                        :name_with_message          => 't-est'
     record.save.should be_truthy
   end
 
@@ -59,7 +62,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -71,7 +75,8 @@ describe Record do
                         :name_with_test_tld         => '_test.test',
                         :name_with_numeric_hostname => '_test',
                         :name_with_blank            => '_test',
-                        :name_with_nil              => '_test'
+                        :name_with_nil              => '_test',
+                        :name_with_message          => '_test'
     record.save.should_not be_truthy
 
     record.should have_at_least(1).errors_on(:name)
@@ -81,6 +86,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_wildcard)
     record.should have_at_least(1).errors_on(:name_with_blank)
     record.should have_at_least(1).errors_on(:name_with_nil)
+    record.should have_at_least(1).errors_on(:name_with_message)
   end
 
   it "should save with hostnames with wildcard if option is true" do
@@ -91,7 +97,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -103,7 +110,8 @@ describe Record do
                         :name_with_test_tld         => '*.test.test',
                         :name_with_numeric_hostname => '*.test',
                         :name_with_blank            => '*.test',
-                        :name_with_nil              => '*.test'
+                        :name_with_nil              => '*.test',
+                        :name_with_message          => '*.test'
     record.save.should_not be_truthy
 
     record.should have_at_least(1).errors_on(:name)
@@ -113,6 +121,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_numeric_hostname)
     record.should have_at_least(1).errors_on(:name_with_blank)
     record.should have_at_least(1).errors_on(:name_with_nil)
+    record.should have_at_least(1).errors_on(:name_with_message)
   end
 
   it "should save with blank hostname" do
@@ -123,7 +132,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_underscores      => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -135,7 +145,8 @@ describe Record do
                         :name_with_test_tld         => '',
                         :name_with_numeric_hostname => '',
                         :name_with_nil              => '',
-                        :name_with_blank            => ''
+                        :name_with_blank            => '',
+                        :name_with_message          => ''
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
@@ -144,6 +155,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_test_tld)
     record.should have_at_least(1).errors_on(:name_with_numeric_hostname)
     record.should have_at_least(1).errors_on(:name_with_nil)
+    record.should have_at_least(1).errors_on(:name_with_message)
   end
 
   it "should save with nil hostname" do
@@ -154,8 +166,17 @@ describe Record do
                         :name_with_valid_tld        => 'test.org',
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
-                        :name_with_blank            => 'test'
+                        :name_with_blank            => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
+  end
+
+  it "should show given error message on invalid hostname" do
+    record = Record.new :name_with_message => nil,
+                        :name => nil
+    record.should be_invalid
+    record.errors[:name_with_message].should include 'test'
+    record.errors[:name].should include 'must be between 1 and 255 characters long'
   end
 
   it "should save when domain name length between 64 and 255" do
@@ -167,7 +188,8 @@ describe Record do
                         :name_with_test_tld         => long_labels + ".test",
                         :name_with_numeric_hostname => long_labels,
                         :name_with_blank            => long_labels,
-                        :name_with_nil              => long_labels
+                        :name_with_nil              => long_labels,
+                        :name_with_message          => long_labels
     record.save.should be_truthy
   end
 
@@ -181,6 +203,7 @@ describe Record do
                         :name_with_numeric_hostname => longname,
                         :name_with_blank            => longname,
                         :name_with_nil              => longname
+                        :name_with_message          => longname
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
@@ -190,6 +213,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_numeric_hostname)
     record.should have_at_least(1).errors_on(:name_with_blank)
     record.should have_at_least(1).errors_on(:name_with_nil)
+    record.should have_at_least(1).errors_on(:name_with_message)
   end
 
   it "should not save with too long hostname label" do
@@ -201,7 +225,8 @@ describe Record do
                         :name_with_test_tld         => long_labels + ".test",
                         :name_with_numeric_hostname => long_labels,
                         :name_with_blank            => long_labels,
-                        :name_with_nil              => long_labels
+                        :name_with_nil              => long_labels,
+                        :name_with_message          => long_labels
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
   end
@@ -218,6 +243,7 @@ describe Record do
       record.name_with_numeric_hostname = testname
       record.name_with_blank            = testname
       record.name_with_nil              = testname
+      record.name_with_message          = testname
       record.save.should_not be_truthy
       record.should have_at_least(1).errors_on(:name)
       record.should have_at_least(1).errors_on(:name_with_underscores)
@@ -227,6 +253,7 @@ describe Record do
       record.should have_at_least(1).errors_on(:name_with_numeric_hostname)
       record.should have_at_least(1).errors_on(:name_with_blank)
       record.should have_at_least(1).errors_on(:name_with_nil)
+      record.should have_at_least(1).errors_on(:name_with_message)
     end
   end
 
@@ -238,7 +265,8 @@ describe Record do
                         :name_with_test_tld         => '-test.test',
                         :name_with_numeric_hostname => '-test',
                         :name_with_blank            => '-test',
-                        :name_with_nil              => '-test'
+                        :name_with_nil              => '-test',
+                        :name_with_message          => '-test'
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
@@ -248,6 +276,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_numeric_hostname)
     record.should have_at_least(1).errors_on(:name_with_blank)
     record.should have_at_least(1).errors_on(:name_with_nil)
+    record.should have_at_least(1).errors_on(:name_with_message)
   end
 
   it "should not save with hostname labels ending with a hyphen" do
@@ -258,7 +287,8 @@ describe Record do
                         :name_with_test_tld         => 'test-.test',
                         :name_with_numeric_hostname => 'test-',
                         :name_with_blank            => 'test-',
-                        :name_with_nil              => 'test-'
+                        :name_with_nil              => 'test-',
+                        :name_with_message          => 'test-'
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
@@ -268,6 +298,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_numeric_hostname)
     record.should have_at_least(1).errors_on(:name_with_blank)
     record.should have_at_least(1).errors_on(:name_with_nil)
+    record.should have_at_least(1).errors_on(:name_with_message)
   end
 
   it "should not save hostnames with numeric only hostname labels" do
@@ -278,7 +309,8 @@ describe Record do
                         :name_with_test_tld         => '12345.test',
                         :name_with_numeric_hostname => '0x12345',
                         :name_with_blank            => '12345',
-                        :name_with_nil              => '12345'
+                        :name_with_nil              => '12345',
+                        :name_with_message          => '12345'
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
     record.should have_at_least(1).errors_on(:name_with_underscores)
@@ -287,6 +319,7 @@ describe Record do
     record.should have_at_least(1).errors_on(:name_with_test_tld)
     record.should have_at_least(1).errors_on(:name_with_blank)
     record.should have_at_least(1).errors_on(:name_with_nil)
+    record.should have_at_least(1).errors_on(:name_with_message)
   end
 
   it "should save hostnames with numeric only hostname labels if option is true" do
@@ -297,7 +330,8 @@ describe Record do
                         :name_with_valid_tld        => 'test.org',
                         :name_with_test_tld         => 'test.test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -309,7 +343,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name_with_valid_tld)
   end
@@ -322,7 +357,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -334,7 +370,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test.invalidtld',
                         :name_with_blank            => 'test.invalidtld',
-                        :name_with_nil              => 'test.invalidtld'
+                        :name_with_nil              => 'test.invalidtld',
+                        :name_with_message          => 'test.invalidtld'
     record.save.should be_truthy
   end
 
@@ -346,7 +383,8 @@ describe Record do
                         :name_with_valid_tld        => 'test.org',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -358,7 +396,8 @@ describe Record do
                         :name_with_valid_tld        => 'test.org',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name_with_test_tld)
   end
@@ -372,7 +411,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:domainname_with_numeric_hostname)
   end
@@ -386,7 +426,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -398,7 +439,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name)
   end
@@ -412,7 +454,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -425,7 +468,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name_with_invalid_root_label)
   end
@@ -439,7 +483,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -452,7 +497,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:name_with_invalid_root_label)
   end
@@ -466,7 +512,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should be_truthy
   end
 
@@ -479,7 +526,8 @@ describe Record do
                         :name_with_test_tld         => 'test.test',
                         :name_with_numeric_hostname => 'test',
                         :name_with_blank            => 'test',
-                        :name_with_nil              => 'test'
+                        :name_with_nil              => 'test',
+                        :name_with_message          => 'test'
     record.save.should_not be_truthy
     record.should have_at_least(1).errors_on(:domainname_with_invalid_root_label)
   end


### PR DESCRIPTION
`message` option on `validates` is ignored so far. This PR fix that.