### PR TITLE
defer inclusion of validator

### DIFF
--- a/lib/validates_hostname.rb
+++ b/lib/validates_hostname.rb
@@ -302,4 +302,6 @@ module PAK
   end
 end
 
-ActiveRecord::Base.send(:include, PAK::ValidatesHostname)
+ActiveSupport.on_load(:active_record) do
+  include PAK::ValidatesHostname
+end


### PR DESCRIPTION
#10 is closed without fix. #12 fixes #10 but it involves other things to resolve.

This PR try to fix #10 with minimum changes.
Refer https://guides.rubyonrails.org/configuring.html#avoid-loading-rails-frameworks. This is true for older Rails.