### PR TITLE
Fix validation to disallow newline characters

### DIFF
--- a/lib/validates_hostname.rb
+++ b/lib/validates_hostname.rb
@@ -118,7 +118,7 @@ class HostnameValidator < ActiveModel::EachValidator
 
       valid_chars = 'a-z0-9\-'
       valid_chars += '_' if options[:allow_underscore]
-      unless label.match?(/^[#{valid_chars}]+$/i)
+      unless label.match?(/\A[#{valid_chars}]+\z/i)
         add_error(record, attribute, :label_contains_invalid_characters, valid_chars: valid_chars.delete('\\'))
       end
     end

--- a/spec/hostname_validator_spec.rb
+++ b/spec/hostname_validator_spec.rb
@@ -112,6 +112,13 @@ RSpec.describe HostnameValidator do
         expect(record).to be_invalid
       end
     end
+
+    it 'is invalid with a newline character' do
+      ["foo.com\n", "foo.com\nserver_name evil", "\nfoo.com"].each do |value|
+        record.hostname = value
+        expect(record).to be_invalid
+      end
+    end
   end
 
   describe 'with fqdn: true' do


### PR DESCRIPTION
Previously, the regular expression allowed newlines in the domain name.

See the regression tests for an MRE.