### PR TITLE
fix: load version dynamically in gemspec

### DIFF
--- a/validates_hostname.gemspec
+++ b/validates_hostname.gemspec
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# stub: validates_hostname 2.0.0 ruby lib
+require_relative 'lib/validates_hostname/version'
 
 Gem::Specification.new do |s|
   s.name = 'validates_hostname'
-  s.version = '2.0.30'
+  s.version = ValidatesHostname::VERSION
   s.required_ruby_version = '>= 3.0.0'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to? :required_rubygems_version=


### PR DESCRIPTION
This PR fixes the failing automated TLD update and release workflow. The workflow was failing during the release step because the gemspec had a hardcoded version '2.0.30' which was already published, while the automated workflow correctly bumped and tagged 'lib/validates_hostname/version.rb'. Loading the version dynamically resolves the issue.