### PR TITLE
chore: refine TLD update automation and add release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Release to RubyGems.org
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout code
@@ -35,3 +35,8 @@ jobs:
 
       - name: Push gem to RubyGems.org
         run: gem push *.gem
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: true

--- a/.github/workflows/tld-update.yml
+++ b/.github/workflows/tld-update.yml
@@ -2,7 +2,7 @@ name: Automated TLD Update and Release
 
 on:
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 1 */3 *"
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ end
 - `allow_wildcard_hostname`: Permits a wildcard character (`*`) as the first label of the hostname (e.g., `*.example.com`). (default: `false`)
 - `allow_root_label`: Permits a trailing dot (root label) in the hostname (e.g., `example.com.`). (default: `false`)
 
+## TLD Updates
+
+The default list of valid TLDs (stored in `data/tlds.txt`) is automatically updated from IANA on a quarterly basis via a GitHub Action. If a new TLD has been released and you need to support it immediately before the next quarterly gem update, you can override the valid TLD list by passing an updated array to the `valid_tlds` option:
+
+```ruby
+# Example of appending a new TLD to the default list
+validates :name, hostname: { 
+  require_valid_tld: true, 
+  valid_tlds: ValidatesHostname::TLDs + ['newtld'] 
+}
+```
+
 ## Examples
 
 Without options:

--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,10 @@ namespace :tlds do
     begin
       response = Net::HTTP.get(uri)
 
+      unless response.match?(/^COM$/i) && response.match?(/^ORG$/i) && response.match?(/^NET$/i)
+        raise "Downloaded TLD list appears invalid (missing COM, ORG, or NET)."
+      end
+
       File.write('data/tlds.txt', response)
 
       puts 'Successfully updated data/tlds.txt.'


### PR DESCRIPTION
A user raised valid concerns (#32) that frequent, automated version bumps without release notes look suspicious. Additionally, weekly updates for TLD changes create unnecessary dependency update fatigue for the community.

Since I like to maintain a zero-maintenance workflow I compromised on the update frequency and added safety nets:

- Reduced the automated update schedule from weekly to quarterly.
- Enabled automated GitHub release notes so users can clearly see what changed in each tag.
- Added a structural safety check to the Rake task to ensure the IANA file is valid before overwriting the local data.
- Documented the quarterly schedule and provided an "escape hatch" in the README for users who need a new TLD immediately.